### PR TITLE
Use Path.Combine to define the output file.

### DIFF
--- a/NUnitOrange/Parser/FolderParser.cs
+++ b/NUnitOrange/Parser/FolderParser.cs
@@ -77,7 +77,7 @@
             // build report for each input file
             foreach (string file in allFiles)
             {
-                data = fileParser.SetFiles(file, outDir + "\\" + Path.GetFileNameWithoutExtension(file) + ".html").AddTopBar(true).BuildReport();
+                data = fileParser.SetFiles(file, Path.Combine(outDir, Path.GetFileNameWithoutExtension(file) + ".html")).AddTopBar(true).BuildReport();
 
                 if (data != null)
                 {
@@ -113,11 +113,11 @@
                     }
                 }
             }
-
+            string outputfile = Path.Combine(outDir, "Index.html");
             // write the entire source with all fixture/test-suite level data row-wise
-            File.WriteAllText(outDir + "\\Index.html", html);
+            File.WriteAllText(outputfile, html);
 
-            Console.WriteLine("\nNUnitOrange executive summary created: " + outDir + "\\Index.html");
+            Console.WriteLine("\nNUnitOrange executive summary created: " + outputfile);
         }
     }
 }


### PR DESCRIPTION
I tried NUnitOrange on Mac and the output was not stored correctly, after looking at the source code I noticed that the output path was defined using "\", this is the path separator on Windows but for Mac/Unix is "/".

Using [Path.Combine](https://msdn.microsoft.com/en-us/library/system.io.path.combine%28v=vs.100%29.aspx) to join the output path with the file name solves the problem.
 